### PR TITLE
more tests, fixed bug where margin/padding cssHooks were returning 3 space strings, changed to $.css

### DIFF
--- a/jquery.csshooks.js
+++ b/jquery.csshooks.js
@@ -14,11 +14,11 @@
         };
     });
     // backgroundPosition get hook
-    var xy = ["X, Y"];
+    var xy = ["X","Y"];
     $.cssHooks.backgroundPosition = {
         get: function( elem, computed, extra ) {
-            return $.map(xy, function( k ) {
-                return $.style( elem, "backgroundPosition" + k ) + "px";
+            return $.map(xy, function( v, i ) {
+                return $.css(elem, "backgroundPosition" + v);
             }).join(" ");
         }
     };

--- a/jquery.csshooks.js
+++ b/jquery.csshooks.js
@@ -3,12 +3,12 @@
  */
 (function($) {
     // padding and margin get hooks
-    var dirs = "Top Right Bottom Right".split(" ");
+    var dirs = "Top Right Bottom Left".split(" ");
     $.each(["padding", "margin"], function( i, hook ) {
         $.cssHooks[ hook ] = {
             get: function( elem, computed, extra ) {
                 return $.map(dirs, function( dir ) {
-                    return $.style( elem, hook + dir );
+                    return $.css( elem, hook + dir );
                 }).join(" ");
             }
         };

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,7 +11,7 @@
 			padding: 1px 2px 3px 4px;
 			width: 10px;
 			height: 10px;
-			background-position: 5px 5px;
+			background-position: 3px 5px;
 		}
 	</style>
 	<script type="text/javascript" src="jquery-1.4.3.js"></script>

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,3 +1,8 @@
+test("width", function() {
+    ok( jQuery("#test").css("width"), "10px" );
+    equals( jQuery("#test").css("width"), "10px", "returns correct values" );
+});
+
 test("padding", function() {
     ok( jQuery("#test").css("padding"), "1px 2px 3px 4px" );
     equals( jQuery("#test").css("padding"), "1px 2px 3px 4px", "returns values in the correct order" );

--- a/tests/test.js
+++ b/tests/test.js
@@ -17,3 +17,13 @@ test("backgroundPosition", function() {
     ok( jQuery("#test").css("backgroundPosition"), "3px 5px" );
     equals( jQuery("#test").css("backgroundPosition"), "3px 5px", "returns values in the correct order" );
 });
+
+test("backgroundPositionX", function() {
+    ok( jQuery("#test").css("backgroundPositionX"), "3px" );
+    equals( jQuery("#test").css("backgroundPositionX"), "3px", "returns proper value" );
+});
+
+test("backgroundPositionY", function() {
+    ok( jQuery("#test").css("backgroundPositionY"), "5px" );
+    equals( jQuery("#test").css("backgroundPositionY"), "5px", "returns proper value" );
+});

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,11 +1,14 @@
 test("padding", function() {
     ok( jQuery("#test").css("padding"), "1px 2px 3px 4px" );
+    equals( jQuery("#test").css("padding"), "1px 2px 3px 4px", "returns values in the correct order" );
 });
 
 test("margin", function() {
     ok( jQuery("#test").css("margin"), "1px 2px 3px 4px" );
+    equals( jQuery("#test").css("margin"), "1px 2px 3px 4px", "returns values in the correct order" );
 });
 
 test("backgroundPosition", function() {
-    ok( jQuery("#test").css("backgroundPosition"), "5px 5px" );
+    ok( jQuery("#test").css("backgroundPosition"), "3px 5px" );
+    equals( jQuery("#test").css("backgroundPosition"), "3px 5px", "returns values in the correct order" );
 });


### PR DESCRIPTION
added some tests to verify that the actual return values were matching the expected values
fixed a bug where margin/padding css weren't returning anything, same with backgroundPosition

I switched it from $.style to use $.css, but only because $.style wasn't working when used this way ( $.style(elem, name ). I wasn't sure which was more "low level" and which was preferred, but switched it just to get the tests passing and the cssHooks to actually return something.
