### PR TITLE
Update gradients.js

### DIFF
--- a/gradients.js
+++ b/gradients.js
@@ -33,12 +33,12 @@
 		divStyle.cssText = cssLinear,
 		linearSettings = function ( value ) {
 			var parts = rLinearSettings.exec( value );
-	        value = value.replace( parts[2] , $.support.linearGradient );
+			value = value.replace( new RegExp(parts[2], 'g') , $.support.linearGradient );
 			return value;
 		},
 		radialSettings = function ( value ) {
 			var parts = rRadialSettings.exec( value );			
-			value = value.replace( parts[2] , $.support.radialGradient );
+			value = value.replace( new RegExp(parts[2], 'g') , $.support.radialGradient );
 			return value;
 		};
 


### PR DESCRIPTION
Bug: hook did not work on multiple gradients. 
Why: "".replace(str, ) only replaces first occurence
Fix: Use regex as an argument to "".replace

This fixed multiple gradients for me.

Example bad css:
$(document.body).css({
background: 'linear-gradient(135deg, #708090 22px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px), linear-gradient(225deg, #708090 22px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px) 0 64px'});
